### PR TITLE
Add LIMIT 1 to coverimage subquery to get correct image using MariaDB

### DIFF
--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -283,7 +283,7 @@ class ShoppProduct extends WPShoppObject {
 		if ( empty($ids) ) return;
 		$table = ShoppDatabaseObject::tablename(ShoppMetaObject::$table);
 		$sortorder = $this->image_order();
-		sDB::query("SELECT * FROM ( SELECT * FROM $table WHERE context='product' AND type='image' AND parent IN ($ids) ORDER BY $sortorder LIMIT 1 ) AS img GROUP BY parent",'array',array($this, 'metasetloader'),'parent','metatype','name',false);
+		sDB::query("SELECT * FROM ( SELECT * FROM $table WHERE context='product' AND type='image' AND parent IN ($ids) ORDER BY $sortorder LIMIT 18446744073709551615 ) AS img GROUP BY parent",'array',array($this, 'metasetloader'),'parent','metatype','name',false);
 	}
 
 	/**

--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -283,7 +283,7 @@ class ShoppProduct extends WPShoppObject {
 		if ( empty($ids) ) return;
 		$table = ShoppDatabaseObject::tablename(ShoppMetaObject::$table);
 		$sortorder = $this->image_order();
-		sDB::query("SELECT * FROM ( SELECT * FROM $table WHERE context='product' AND type='image' AND parent IN ($ids) ORDER BY $sortorder ) AS img GROUP BY parent",'array',array($this, 'metasetloader'),'parent','metatype','name',false);
+		sDB::query("SELECT * FROM ( SELECT * FROM $table WHERE context='product' AND type='image' AND parent IN ($ids) ORDER BY $sortorder LIMIT 1 ) AS img GROUP BY parent",'array',array($this, 'metasetloader'),'parent','metatype','name',false);
 	}
 
 	/**


### PR DESCRIPTION
Add LIMIT 1 to subquery to make ORDER BY work with MariaDB. MariaDB ignores ORDER BY in a subquery unless LIMIT is used. Reference: https://mariadb.com/kb/en/why-is-order-by-in-a-from-subquery-ignored/.  This provides a workaround using LIMIT, but could possibly use a further refactor to not use the subquery at all.