### PR TITLE
Add label options to month and year card fields.

### DIFF
--- a/api/theme/checkout.php
+++ b/api/theme/checkout.php
@@ -373,7 +373,7 @@ class ShoppCheckoutThemeAPI implements ShoppAPI {
 		$label = ( ! empty($options['label']) ) ? $options['label'] : '';
 		$menu[] = '<select name="' . $name . '" id="' . $id . '" ' . inputattrs($options, $select_attrs) . '>';
 		$menu[] = '<option>' . $label . '</option>';
-		$menu[] = menuoptions($months, $options['value']);
+		$menu[] = menuoptions($years, $options['value']);
 		$menu[] = '</select>';
 
 		return join('', $menu);

--- a/api/theme/checkout.php
+++ b/api/theme/checkout.php
@@ -303,8 +303,9 @@ class ShoppCheckoutThemeAPI implements ShoppAPI {
 		$months = array('01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12');
 
 		$menu = array();
+		$label = ( ! empty($options['label']) ) ? $options['label'] : '';
 		$menu[] = '<select name="' . $name . '" id="' . $id . '" ' . inputattrs($options, $select_attrs) . '>';
-		$menu[] = '<option></option>';
+		$menu[] = '<option>' . $label . '</option>';
 		$menu[] = menuoptions($months, $options['value']);
 		$menu[] = '</select>';
 
@@ -369,9 +370,10 @@ class ShoppCheckoutThemeAPI implements ShoppAPI {
 		$years = array_map( create_function('$n','return sprintf("%02d", $n);'), range((int)$thisyear, (int)$thisyear + $options['max'] ) );
 
 		$menu = array();
+		$label = ( ! empty($options['label']) ) ? $options['label'] : '';
 		$menu[] = '<select name="' . $name . '" id="' . $id . '" ' . inputattrs($options, $select_attrs) . '>';
-		$menu[] = '<option></option>';
-		$menu[] = menuoptions($years, $options['value']);
+		$menu[] = '<option>' . $label . '</option>';
+		$menu[] = menuoptions($months, $options['value']);
 		$menu[] = '</select>';
 
 		return join('', $menu);


### PR DESCRIPTION
Hey,

A really simple addition to the card fields which will give developers the flexibility to specify text in the first `<option>` as opposed to just having a blank one.