### PR TITLE
Added custom purchase item data to default receipt template.

### DIFF
--- a/templates/receipt.php
+++ b/templates/receipt.php
@@ -82,6 +82,7 @@
 						<?php shopp( 'purchase.item-sku' ); ?><br />
 						<?php shopp( 'purchase.item-download' ); ?>
 						<?php shopp( 'purchase.item-addons-list' ); ?>
+						<?php shopp( 'purchase.item-inputs-list' ); ?>
 					</td>
 					<td><?php shopp( 'purchase.item-quantity' ); ?></td>
 					<td class="money"><?php shopp( 'purchase.item-unitprice' ); ?></td>


### PR DESCRIPTION
I noticed that the default receipt file was missing this information, which is important for stores that use it. This pull request adds it.