### PR TITLE
fix #3148

### DIFF
--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -1223,7 +1223,8 @@ class ShoppProduct extends WPShoppObject {
 			$Post = new StdClass;
 			$Post->ID = $id;
 			$Post->post_type = ShoppProduct::$posttype;
-			wp_transition_post_status($status, $Product->status, $Post);
+			$old_status = if ( ! empty($Product->status) ) ? $Product->status : get_post_status($id);
+			wp_transition_post_status($status, $old_status, $Post);
 		}
 
 		return true;


### PR DESCRIPTION
A change has been made to this code already but it is not error/warning free yet.

When using the shopp_add_product() function there is no $Product variable.