### PR TITLE
Replace 'Category' with the singular Taxonomy name

### DIFF
--- a/api/theme/storefront.php
+++ b/api/theme/storefront.php
@@ -985,7 +985,8 @@ class ShoppStorefrontThemeAPI implements ShoppAPI {
 		$options = wp_parse_args($options, array(
 			'dropdown' => false,
 			'default' => $default,
-			'title' => ''
+			'title' => '',
+			'class' => ''
 		));
 		extract($options, EXTR_SKIP);
 
@@ -1003,7 +1004,7 @@ class ShoppStorefrontThemeAPI implements ShoppAPI {
 				foreach ($_GET as $key => $value)
 					if ( 'sort' != $key ) $_[] = '<input type="hidden" name="' . $key . '" value="' . $value . '" />';
 			}
-			$_[] = '<select name="sort" class="shopp-orderby-menu">';
+			$_[] = '<select name="sort" class="shopp-orderby-menu '.$class.'">';
 			$_[] = menuoptions($menuoptions,$default,true);
 			$_[] = '</select>';
 			$_[] = '</form>';

--- a/core/ui/products/ui.php
+++ b/core/ui/products/ui.php
@@ -125,7 +125,7 @@ function shopp_categories_meta_box ($Product,$options) {
 	<ul id="<?php echo $taxonomy; ?>-tabs" class="category-tabs">
 		<li class="tabs"><a href="#<?php echo $taxonomy; ?>-all" tabindex="3"><?php _e('Show All'); ?></a></li>
 		<li class="hide-if-no-js"><a href="#<?php echo $taxonomy; ?>-pop" tabindex="3"><?php _e( 'Popular','Shopp' ); ?></a></li>
-		<li class="hide-if-no-js new-category"><a href="#<?php echo $taxonomy; ?>-all" tabindex="3"  class="new-category-tab"><?php _e( 'New Category' ); ?></a></li>
+		<li class="hide-if-no-js new-category"><a href="#<?php echo $taxonomy; ?>-all" tabindex="3"  class="new-category-tab"><?php _e( 'New '.$tax->labels->singular_name ); ?></a></li>
 	</ul>
 </div><?php
 }


### PR DESCRIPTION
In the products editor, custom taxonomies show a 'New Category' tab/link under them. This change makes the tab/link name show the taxonomy singular name.