### PR TITLE
Subscription Related Changes and Bug Fix

### DIFF
--- a/api/theme/cart.php
+++ b/api/theme/cart.php
@@ -612,7 +612,8 @@ class ShoppCartThemeAPI implements ShoppAPI {
 	 * @return bool True if shipping methods are available, false otherwise
 	 **/
 	public static function has_shipping_methods ( $result, $options, $O ) {
-		return ShoppShippingThemeAPI::has_options( $result, $options, $O );
+		if ($O->shipped)
+			return ShoppShippingThemeAPI::has_options( $result, $options, $O );
 	}
 
 	/**

--- a/api/theme/product.php
+++ b/api/theme/product.php
@@ -69,6 +69,7 @@ class ShoppProductThemeAPI implements ShoppAPI {
 		'hasvariants' => 'has_variants',
 		'hasimages' => 'has_images',
 		'hasspecs' => 'has_specs',
+		'hassubscription' => 'has_subscription',
 		'hastags' => 'has_tags',
 		'id' => 'id',
 		'image' => 'image',
@@ -994,6 +995,25 @@ class ShoppProductThemeAPI implements ShoppAPI {
 
 		if ( count($O->specs) > 0 ) return true;
 		else return false;
+
+	}
+
+	/**
+	 * Checks if the product has a subscription price line
+	 *
+	 * @api `shopp('product.has-subscription')`
+	 * @since 1.0
+	 *
+	 * @param string       $result  The output
+	 * @param array        $options The options
+	 * @param ShoppProduct $O       The working object
+	 * @return bool True if specs exist, false otherwise
+	 **/
+	public static function has_subscription ( $result, $options, $O ) {
+
+		foreach ( $O->prices as $price ){
+			if ( "Subscription" == $price->type ) return true;
+		}
 
 	}
 
@@ -2035,6 +2055,34 @@ class ShoppProductThemeAPI implements ShoppAPI {
 			$saleprice = Shopp::roundprice( self::_taxed((float)$saleprice, $O, $variation->tax, $taxes) );
 			if ( Shopp::str_true($money) ) $_[] = money($saleprice);
 			else $_[] = $saleprice;
+		}
+
+		// return recurring interval, period, cycles
+		if ( array_key_exists('recurring', $options) ) {
+			if ("Subscription" == $variation->type) return true;
+		}
+		if ( array_key_exists('recurring-interval', $options) ) {
+			$_[] = $variation->recurring['interval'];
+		}
+		if ( array_key_exists('recurring-period', $options) ) {
+			$_[] = $variation->recurring['period'];
+		}
+		if ( array_key_exists('recurring-cycles', $options) ) {
+			$_[] = $variation->recurring['cycles'];
+		}
+		// trial period, if it exists, and interval, period, cycles
+		if ( array_key_exists('trial', $options) ) {
+		// shopp_debug("Object: " . print_r($O, true));
+			return Shopp::str_true($variation->recurring['trial']);
+		}
+		if ( array_key_exists('trial-price', $options) ) {
+			$_[] = $variation->recurring['trialprice'];
+		}
+		if ( array_key_exists('trial-interval', $options) ) {
+			$_[] = $variation->recurring['trialint'];
+		}
+		if ( array_key_exists('trial-period', $options) ) {
+			$_[] = $variation->recurring['trialperiod'];
 		}
 
 		if ( array_key_exists('weight', $options) )

--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -587,6 +587,9 @@ class ShoppCartItem {
 			}
 
 			$this->data[_x('Trial Period','Item trial period label','Shopp')] = $trial_label;
+		} else {
+			// catches variant changes when a different subscription variant doesn't have a trial
+			unset($this->data[_x('Trial Period','Item trial period label','Shopp')]);
 		}
 
 		// pick untranslated label

--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -194,6 +194,10 @@ class ShoppCartItem {
 				$trial = $this->trial();
 				$this->unitprice = $trial['price'];
 			}
+		} else {
+			// remove subscription labels in case they were set earlier
+			unset($this->data[_x('Subscription','Subscription terms label','Shopp')]);
+			unset($this->data[_x('Trial Period','Item trial period label','Shopp')]);
 		}
 
 		// Map out the selected menu name and option


### PR DESCRIPTION
Updated theme API to include some new subscription related functions (to be filled out more later).

Also fixed a minor bug in the Trial/Subscription label code when a product has two subscription variants—one with a trial price and the other without—that keeps the “Trial Price” label (and in some instances the trial text too) visible in the Cart after it no longer applies.