### PR TITLE
Switch to sanitize_title()

### DIFF
--- a/api/product.php
+++ b/api/product.php
@@ -60,7 +60,7 @@ function shopp_add_product ( $data = array() ) {
 
 	// Set Product slug
 	if ( ! empty($data['slug'])) $Product->slug = $data['slug'];
-	if (empty($Product->slug)) $Product->slug = sanitize_title_with_dashes($Product->name);
+	if (empty($Product->slug)) $Product->slug = sanitize_title($Product->name);
 	$Product->slug = wp_unique_post_slug($Product->slug, $Product->id, $Product->status, ShoppProduct::posttype(), 0);
 
 	$Product->updates($data, array('meta','categories','prices','tags', 'publish'));


### PR DESCRIPTION
Switching from sanitize_title_with_dashes() to sanitize_title() makes the shopp_product_add() handle slugs the same way the Product Editor does.

It also solves a problem with importing products.
When `$data['slug'] = sanitize_title($name);` is used in `shopp_product_add($data);`, products with the same name get the same slug.