### PR TITLE
Properly remove shipping tax if not applicable.

### DIFF
--- a/core/model/Cart.php
+++ b/core/model/Cart.php
@@ -626,8 +626,11 @@ class ShoppCart extends ListFramework {
 
 		$Totals->register( new OrderAmountShipping( array('id' => 'cart', 'amount' => $Shipping->calculate() ) ) );
 
-		if ( apply_filters( 'shopp_tax_shipping', shopp_setting_enabled('tax_shipping') ) )
+		if ( apply_filters( 'shopp_tax_shipping', shopp_setting_enabled('tax_shipping') ) ) {
 			$Totals->register( new OrderAmountShippingTax( $Totals->total('shipping') ) );
+		} else {			
+			$Totals->takeoff( OrderAmountShippingTax::$register, 'shipping' ); // if not applicable, make sure we scrub
+		}
 
 		// Calculate discounts
 		$Totals->register( new OrderAmountDiscount( array('id' => 'cart', 'amount' => $Discounts->amount() ) ) );


### PR DESCRIPTION
When filtering whether to tax shipping, if you calculate taxes with shipping and then calculate without, the shipping tax is never removed leading to odd orders where someone has a small remaining tax left on what should have been untaxed order.

This PR seems to fix it elegantly enough. 