### PR TITLE
Added 'shopp_collection_load_options' filter

### DIFF
--- a/core/model/Collection.php
+++ b/core/model/Collection.php
@@ -76,6 +76,7 @@ class ProductCollection implements Iterator {
 			'debug' => false		// Output the query for debugging
 		);
 		$loading = array_merge($defaults, $options);
+		$loading = apply_filters("shopp_collection_load_options", $loading);
 		$loading = apply_filters("shopp_{$slug}_collection_load_options", $loading);
 		extract($loading);
 


### PR DESCRIPTION
A filter to change the load options for named collections exists, namely 'shopp_{$slug}_collection_load_options'. This works well for things like smart categories. It doesn't work for custom categories. The filter added in this PR can be used when ALL collection loading occasions need to be filtered.

For a usage scenario, I'm using this to hide products with certain taxonomy terms from all views unless certain customer account credentials exist.