### PR TITLE
Fixed #3140 Fetch purchase records by 'authed' rather than 'authorized'

### DIFF
--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -302,7 +302,7 @@ class ShoppProduct extends WPShoppObject {
 		if ( empty($ids) ) return;
 		$purchase = ShoppDatabaseObject::tablename(ShoppPurchase::$table);
 		$purchased = ShoppDatabaseObject::tablename(Purchased::$table);
-		$query = "SELECT p.product as id,sum(p.quantity) AS sold,sum(p.total) AS grossed FROM $purchased as p INNER JOIN $purchase AS o ON p.purchase=o.id WHERE p.product IN ($ids) AND o.txnstatus IN ('authorized','captured') GROUP BY p.product";
+		$query = "SELECT p.product as id,sum(p.quantity) AS sold,sum(p.total) AS grossed FROM $purchased as p INNER JOIN $purchase AS o ON p.purchase=o.id WHERE p.product IN ($ids) AND o.txnstatus IN ('authed','captured') GROUP BY p.product";
 		sDB::query($query, 'array', array($this, 'sold'));
 	}
 


### PR DESCRIPTION
OfflinePayment purchases get added to `wp_shopp_purchase` with a `txnstatus = 'authed'`. This changeset updates the query that fetches rows from that table to look for records where `txnstatus` is `authed` or `captured` (rather than `authorized` or `captured`).