### PR TITLE
Modifications to session on initial page load are not saved

### DIFF
--- a/core/library/Session.php
+++ b/core/library/Session.php
@@ -59,9 +59,10 @@ abstract class ShoppSessionFramework {
 
 		$this->trim(); // Cleanup stale sessions
 
-		if ( $this->open() ) // Reopen an existing session
-			add_action('shutdown', array($this, 'save')); // Save on shutdown
-		else $this->cook(); // Cook a new session cookie
+		if ( ! $this->open() ) // Reopen an existing session
+			$this->cook(); // Cook a new session cookie
+			
+		add_action('shutdown', array($this, 'save')); // Save on shutdown
 
 		shopp_debug('Session started ' . str_repeat('-', 64));
 


### PR DESCRIPTION
The shtudown save handler is only added when an existing session has been re-opened. 

So, if you try to add something to the cart or otherwise change a user's session data during their initial page load, none of those changes are saved.

This PR fixes it. 