### PR TITLE
Fixed #3347 Ensure a ShoppBaseLocale object is available

### DIFF
--- a/api/core.php
+++ b/api/core.php
@@ -131,6 +131,8 @@ function ShoppBaseLocale () {
 function ShoppBaseCurrency () {
 	$Shopp = Shopp::object();
 	if ( empty($Shopp) ) return false;
+	if ( empty($Shopp->Locale) )
+		$Shopp->Locale = new ShoppBaseLocale();
 	return $Shopp->Locale->currency();
 }
 


### PR DESCRIPTION
Prevents fatal errors particularly at plugin install.