### PR TITLE
Add message to be displayed after successful password change.

### DIFF
--- a/core/model/Customer.php
+++ b/core/model/Customer.php
@@ -476,6 +476,7 @@ class ShoppCustomer extends ShoppDatabaseObject {
 		$this->updated(self::PROFILE, true);
 
 		if ( $this->_password_change )
+			new ShoppError(__('Your password has been changed. Please log in again below.'), 'password_change_redirect', SHOPP_ERR);
 			Shopp::redirect(Shopp::url(false, 'account'));
 
 	}


### PR DESCRIPTION
This started as a client request, and core hack, but I think it merits a tiny PR.

This change adds a message to be displayed to customers after their password is manually reset by them from their profile page.

**Reason**
Currently when a user resets their password they are logged out and redirected to /shop/account [here](https://github.com/ingenesis/shopp/blob/master/core/model/Customer.php#L479). After some user testing it's become apparent that some users think that the process has failed and that they need to try again. 

**Improvements?**
- Should I be passing the text domain to `__()`?
- Any reason to use `Shopp::__(` ([example here](https://github.com/ingenesis/shopp/blob/master/core/flow/Pages.php#L456)) instead of just `__()`?
- Is it ok to use an arbitrary error code like 'password_change_redirect'?
- Is `SHOPP_ERR` ok to use as the 'level', is there maybe a more suitable one for notices and info messages?