### PR TITLE
remove rogue hex value that breaks product row-actions visibility

### DIFF
--- a/core/ui/styles/admin.css
+++ b/core/ui/styles/admin.css
@@ -79,7 +79,7 @@ span.lowstock.warning { background: #C60; }
 /** List managers **/
 h2 a.add-new { font-style: normal; margin: 0px 6px; position: relative; top: -3px; font-family:'Lucida Grande',Verdana,Arial,'Bitstream Vera Sans',sans-serif;text-transform:none;}
 .row-actions { visibility:hidden;padding:2px 0 0; }
-tr:hover .row-actions,464646
+tr:hover .row-actions,
 div.comment-item:hover .row-actions { visibility:visible; }
 
 /** Editors Global **/


### PR DESCRIPTION
The row actions that show under product titles in the Products admin list are missing on mouseover:
![image](https://cloud.githubusercontent.com/assets/3437528/11744300/0242c31e-a007-11e5-9766-393199043c9c.png)

Not sure how this error in an old commit [(here)](https://github.com/ingenesis/shopp/commit/55b5f2277675548953f282c07fde454005cb8855#diff-a096b7ae5f5136a791ec5b85ebca3291R80) got into 1.3.x as it isn't in 1.3.9 on the WP Repo, but it did... so I've removed it. 

The row-actions display on hover again now:
![image](https://cloud.githubusercontent.com/assets/3437528/11744315/22ec2376-a007-11e5-9603-b046af5ab846.png)
