### PR TITLE
fix for discounts not being removed

### DIFF
--- a/core/model/Discounts.php
+++ b/core/model/Discounts.php
@@ -303,8 +303,9 @@ class ShoppDiscounts extends ListFramework {
 		if ( $this->shipping($Discount) ) // Flag shipping changes
 			$Discount->shipfree(false);   // Remove free shipping if this is a free shipping discount (@see #2885)
 
-		if ( isset($this->codes[ $Discount->code() ]) ) {
-			unset($this->codes[ $Discount->code() ]);
+		$code = trim(strtolower($Discount->code()));
+		if ( isset($this->codes[ $code ]) ) {
+			unset($this->codes[ $code ]);
 			return;
 		}
 


### PR DESCRIPTION
applied discount codes are trim()'d and strtolower()'d before storing, the discount code being removed was not being processed the same way before comparing to the applied codes, so it was not being removed from the order.