### PR TITLE
Shopp div fixes

### DIFF
--- a/core/flow/Pages.php
+++ b/core/flow/Pages.php
@@ -782,6 +782,11 @@ class ShoppThanksPage extends ShoppPage {
 		if ( ! $wp_query->is_main_query() || ! is_shopp_page('thanks') ) return $content;
 
 		ob_start();
+
+		$Errors = ShoppErrorStorefrontNotices();
+		if ( $Errors->exist() )
+			echo ShoppStorefront::errors(array('errors-checkout.php', 'errors.php'));
+
 		locate_shopp_template(array('thanks.php'), true);
 		$content = ob_get_contents();
 		ob_end_clean();

--- a/core/flow/Storefront.php
+++ b/core/flow/Storefront.php
@@ -80,7 +80,7 @@ class ShoppStorefront extends ShoppFlowController {
 		add_filter( 'shopp_checkout_page',		array('Storefront', 'wrapper') );
 		add_filter( 'shopp_account_template',	array('Storefront', 'wrapper') );
 		add_filter( 'shopp_category_template',	array('Storefront', 'wrapper') );
-		add_filter( 'shopp_order_receipt',		array('Storefront', 'wrapper') );
+		add_filter( 'shopp_thanks',		array('Storefront', 'wrapper') );
 		add_filter( 'shopp_account_manager',	array('Storefront', 'wrapper') );
 		add_filter( 'shopp_account_vieworder',	array('Storefront', 'wrapper') );
 		add_filter( 'the_content',				array($this, 'autowrap'), 99 );


### PR DESCRIPTION
Makes the shopp div and shopp errors behavior and HTML code consistent on every Shopp page.

Previously it was the same on every page accept the thank you and order receipt pages.