### PR TITLE
Respect WP settings on product creation

### DIFF
--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -80,6 +80,10 @@ class ShoppProduct extends WPShoppObject {
 		$this->init(self::$table, $key);
 		$this->type = self::$posttype;
 		$this->load($id, $key);
+		if ( ! $id ) { 
+			$this->ping_status = get_option('default_ping_status');
+			$this->comment_status = get_option('default_comment_status');			
+		}		
 	}
 
 	public function save () {


### PR DESCRIPTION
By default on new product creation, ping_status and comment_status are set to 'open', ignoring the value for these options in WP settings.