### PR TITLE
Fixed PHP error on admin pages with Wordpress 4.3+

### DIFF
--- a/core/library/UI.php
+++ b/core/library/UI.php
@@ -333,6 +333,9 @@ class ShoppAdminListTable extends WP_List_Table {
 		$columns = get_column_headers( $this->_screen );
 		$hidden = get_hidden_columns( $this->_screen );
 		$screen = get_current_screen();
+		$primary = method_exists($this, "get_primary_column_name")
+			? $this->get_primary_column_name()
+			: null;
 
 		$_sortable = apply_filters( "manage_{$screen->id}_sortable_columns", $this->get_sortable_columns() );
 
@@ -348,8 +351,7 @@ class ShoppAdminListTable extends WP_List_Table {
 			$sortable[$id] = $data;
 		}
 
-
-		return array( $columns, $hidden, $sortable );
+		return array( $columns, $hidden, $sortable, $primary );
 	}
 
 	public function get_columns() {


### PR DESCRIPTION
A 4th array element has been added to the array returned by ``WP_List_Table::get_column_info`` in WP4.3, which causes an error in ``ShoppAdminListTable::print_column_headers`` because that class has its own ``get_column_info`` method without this 4th element.