### PR TITLE
Added prefetch checking for Chrome and Safari.

### DIFF
--- a/core/library/Session.php
+++ b/core/library/Session.php
@@ -221,8 +221,12 @@ abstract class ShoppSessionFramework {
 	 **/
 	public function save () {
 
-		// Don't update the session for prefetch requests (via <link rel="next" /> tags) currently FF-only
-		if ( isset($_SERVER['HTTP_X_MOZ']) && 'prefetch' == $_SERVER['HTTP_X_MOZ'] ) return false;
+		// Don't update the session for prefetch requests (via <link rel="next" /> or <link rel="prefetch" /> tags)
+		if (isset($_SERVER['HTTP_X_MOZ']) && $_SERVER['HTTP_X_MOZ'] == "prefetch" //Firefox
+			|| isset($_SERVER["HTTP_X_PURPOSE"]) //Chrome/Safari
+				&& in_array($_SERVER["HTTP_X_PURPOSE"], array("preview", "instant"))
+			) 
+			return false;
 
 		if ( empty($this->session) ) return false; // Do not save if there is no session id
 


### PR DESCRIPTION
Added prefetch checking for Chrome and Safari. IE/Edge currently doesn't send any kind of prefetch identifier in the HTTP headers, although it does do prefetch requests via <link rel="next" /> and <link rel="prefetch" /> tags.
