### PR TITLE
Paypal Standard 'address_override' filter

### DIFF
--- a/core/flow/Registration.php
+++ b/core/flow/Registration.php
@@ -45,7 +45,7 @@ class ShoppRegistration extends ShoppFormPostFramework {
 
 		if ( empty($_POST) ) return;
 
-		$this->updateform();
+		$this->posted();
 
 		if ( ! self::submitted() ) return;
 

--- a/gateways/PayPal/PayPalStandard.php
+++ b/gateways/PayPal/PayPalStandard.php
@@ -415,7 +415,7 @@ class ShoppPayPalStandard extends GatewayFramework implements GatewayModule {
 			$_['last_name'] = join(' ', $shipname);
 		}
 
-		$_['address_override'] 		= apply_filters( 'shopp_paypalstandard_address_override', 1 );
+		$_['address_override'] 		= apply_filters( 'shopp_paypalstandard_addressoverride', 1 );
 
 		$_['address1']				= $Address->address;
 		if (!empty($Address->xaddress))

--- a/gateways/PayPal/PayPalStandard.php
+++ b/gateways/PayPal/PayPalStandard.php
@@ -415,7 +415,7 @@ class ShoppPayPalStandard extends GatewayFramework implements GatewayModule {
 			$_['last_name'] = join(' ', $shipname);
 		}
 
-		$_['address_override'] 		= 1;
+		$_['address_override'] 		= apply_filters( 'shopp_paypalstandard_address_override', 1 );
 
 		$_['address1']				= $Address->address;
 		if (!empty($Address->xaddress))


### PR DESCRIPTION
This addresses #3293 along with a fix I found while testing. On master, if you try to login with an existing user account during checkout, Shopp would return a fatal error regarding the `updateform()` method which no longer exists. Switched to the new `posted()` method.