### PR TITLE
Fix for #3443

### DIFF
--- a/shipping/core/OrderWeight.php
+++ b/shipping/core/OrderWeight.php
@@ -7,7 +7,7 @@
  * @author Jonathan Davis
  * @copyright Ingenesis Limited, 27 April, 2008
  * @package shopp
- * @version 1.2
+ * @version 1.2.1
  * @since 1.2
  *
  **/
@@ -40,17 +40,18 @@ class OrderWeight extends ShippingFramework implements ShippingModule {
 			$amount = 0;
 			$matched = false;
 			$tiers = array_reverse($tiers);
-			
+
 			foreach ( $tiers as $tier ) {
 				extract($tier);
 				$amount = Shopp::floatval($rate);			// Capture the rate amount
-				
-				if ( $this->weight >= $threshold ) {
+				$weight = Shopp::floatval($threshold);		// Convert to float so comparison is correct
+
+				if ( $this->weight >= $weight ) {
 					$matched = true;
-					break;	
-				} 
+					break;
+				}
 			}
-			
+
 			if ( ! $matched ) return $options;
 
 			$rate = array(


### PR DESCRIPTION
Fixes an issue with decimal comma notation where weight comparison for small weights would fail. Updated version number too, just cause.