### PR TITLE
Flush rewrite rules during activation hook, no need to defer | #3425

### DIFF
--- a/core/flow/Install.php
+++ b/core/flow/Install.php
@@ -81,7 +81,7 @@ class ShoppInstallation extends ShoppFlowController {
 
 		shopp_set_setting('updates', false);
 
-		add_action('init', 'flush_rewrite_rules', 99);
+		flush_rewrite_rules();
 		return true;
 	}
 


### PR DESCRIPTION
Re https://github.com/ingenesis/shopp/issues/3425 the rewrite rules flush needed during activation was being deferred until the `init` action - however `init` has already fired by the time the activation hook runs. This change simply makes the call directly.