### PR TITLE
Accommodate delete image size requests | #3395

### DIFF
--- a/core/library/Screen.php
+++ b/core/library/Screen.php
@@ -327,17 +327,6 @@ abstract class ShoppScreenController extends ShoppRequestFormFramework {
 	}
 
 	/**
-	 * Lookout for image size delete requests or else defer to the parent class's
-	 * posted() method.
-	 *
-	 * @return bool
-	 */
-	public function posted() {
-		if ( $this->request( 'delete' ) ) return true;
-		else return parent::posted();
-	}
-
-	/**
 	 * Registers callback handlers for actions or ops
 	 *
 	 * @since 1.4

--- a/core/library/Screen.php
+++ b/core/library/Screen.php
@@ -327,6 +327,17 @@ abstract class ShoppScreenController extends ShoppRequestFormFramework {
 	}
 
 	/**
+	 * Lookout for image size delete requests or else defer to the parent class's
+	 * posted() method.
+	 *
+	 * @return bool
+	 */
+	public function posted() {
+		if ( $this->request( 'delete' ) ) return true;
+		else return parent::posted();
+	}
+
+	/**
 	 * Registers callback handlers for actions or ops
 	 *
 	 * @since 1.4

--- a/core/screens/Images.php
+++ b/core/screens/Images.php
@@ -21,6 +21,17 @@ defined( 'WPINC' ) || header( 'HTTP/1.1 403' ) & exit; // Prevent direct access
  **/
 class ShoppScreenImages extends ShoppSettingsScreenController {
 
+	/**
+	 * Lookout for image size delete requests or else defer to the parent class's
+	 * posted() method.
+	 *
+	 * @return bool
+	 */
+	public function posted() {
+		if ( $this->request( 'delete' ) ) return true;
+		else return parent::posted();
+	}
+
 	public function assets() {
 		shopp_enqueue_script('jquery-tmpl');
 		shopp_enqueue_script('imageset');


### PR DESCRIPTION
Re https://github.com/ingenesis/shopp/issues/3395 this allows image sizes to be deleted. 

Alternatives might include rejigging `ShoppScreenController::process()` so it tests the result of a new `ShoppRequestFormFramework::requested()` method or something of that order, though this is a pretty straightforward solution.