### PR TITLE
Have ShoppScreenCategories and ShoppScreenCategoryEditor inherit load_category()

### DIFF
--- a/core/screens/Categories.php
+++ b/core/screens/Categories.php
@@ -27,7 +27,22 @@ class ShoppAdminCategories extends ShoppAdminPostController {
 
 }
 
-class ShoppScreenCategories extends ShoppScreenController {
+/**
+ * Contains methods common to a number of different category screen classes.
+ */
+class ShoppScreenCategoriesBase extends ShoppScreenController {
+	/**
+	 * @param WP_Term $term
+	 * @return ProductCategory
+	 */
+	public function load_category( $term ) {
+		$Category = new ProductCategory();
+		$Category->populate( $term );
+		return $Category;
+	}
+}
+
+class ShoppScreenCategories extends ShoppScreenCategoriesBase {
 
 	public $worklist = array();
 
@@ -422,7 +437,7 @@ class ShoppScreenCategoryArrangeProducts extends ShoppScreenController {
 	}
 }
 
-class ShoppScreenCategoryEditor extends ShoppScreenController {
+class ShoppScreenCategoryEditor extends ShoppScreenCategoriesBase {
 
 	public function assets () {
 		wp_enqueue_script('postbox');

--- a/core/screens/Categories.php
+++ b/core/screens/Categories.php
@@ -526,13 +526,6 @@ class ShoppScreenCategoryEditor extends ShoppScreenCategoriesBase {
 		$ids = array_keys($Categories);
 		return $ids;
 	}
-
-	public function load_category ( $term, $taxonomy ) {
-		$Category = new ProductCategory();
-		$Category->populate($term);
-
-		return $Category;
-	}
 	
 	public function load () {
 


### PR DESCRIPTION
`ShoppScreenCategories` and `ShoppScreenCategoryEditor` both need to use the same `load_category()` method but, currently, it exists only in the latter. This change moves it to a new class (extending `ShoppScreenController`) which they in turn can inherit from.

Should fix the bug reported in #3491 which was caused by a bad reference to the non-existent `ShoppScreenCategories->load_category()` method.