### PR TITLE
Fix #3530

### DIFF
--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -212,7 +212,7 @@ class ShoppCartItem {
 
 		$this->packaging = Shopp::str_true( shopp_product_meta($Product->id, 'packaging') );
 
-		if ( ! empty($Price->download) ) $this->download = $Price->download;
+		$this->download = ( ! empty($Price->download) ) ? $Price->download : false;
 
 		$this->shipped = ( 'Shipped' == $Price->type );
 


### PR DESCRIPTION
Reset download when changing variants in cart. Otherwise the download flag will keep the `true` value when switching from downloadable variant to non-downloadable variant.