### PR TITLE
Fix related-products showing current product when no tags set

### DIFF
--- a/core/model/Collection.php
+++ b/core/model/Collection.php
@@ -2018,29 +2018,29 @@ class RelatedProducts extends SmartCollection {
 			if ( empty($scope) ) $scope = array_keys($this->product->tags);
 		}
 
-		if ( empty($scope) ) return false;
+		if ( empty($scope) ) {
+			$loading = compact('where');
+		} else {
+		  $this->name = Shopp::__("Products related to") . " &quot;" . stripslashes($name) . "&quot;";
+			$this->uri = urlencode($slug);
+			$this->controls = false;
 
-		$this->name = Shopp::__("Products related to") . " &quot;" . stripslashes($name) . "&quot;";
-		$this->uri = urlencode($slug);
-		$this->controls = false;
-
-		global $wpdb;
-		$joins[ $wpdb->term_relationships ] = "INNER JOIN $wpdb->term_relationships AS tr ON (p.ID=tr.object_id)";
-		$joins[ $wpdb->term_taxonomy ] = "INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
-		$where[] = "tt.term_id IN (" . join(',', $scope) . ")";
-		$columns = 'COUNT(p.ID) AS score';
-		$groupby = 'p.ID';
-		$orderby = 'score DESC';
-		$loading = compact('columns', 'joins', 'where', 'groupby', 'orderby');
+			global $wpdb;
+			$joins[ $wpdb->term_relationships ] = "INNER JOIN $wpdb->term_relationships AS tr ON (p.ID=tr.object_id)";
+			$joins[ $wpdb->term_taxonomy ] = "INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
+			$where[] = "tt.term_id IN (" . join(',', $scope) . ")";
+			$columns = 'COUNT(p.ID) AS score';
+			$groupby = 'p.ID';
+			$orderby = 'score DESC';
+			$loading = compact('columns', 'joins', 'where', 'groupby', 'orderby');
+		}
 
 		$this->loading = array_merge($options, $loading);
 
 		if ( isset($options['order']) ) $this->loading['order'] = $options['order'];
 		if ( isset($options['controls']) && Shopp::str_true($options['controls']) )
 			unset($this->controls);
-
 	}
-
 }
 
 /**


### PR DESCRIPTION
Previously [shopp('storefront.related-products')](https://shopplugin.net/api/storefront-related-products/) will show the currently view product in the list of related products, if no tags are set.

This PR returns the 'WHERE' clause which excludes the current product ID (with ```$where = array("p.id != {$this->product->id}");```) even if no tags are found. The previous version just returned false, so every product was displayed.

I believe this is a non-breaking change, and have tested it on two live sites and two dev sites for both 1.3.10 and 1.3.11.