### PR TITLE
Fix several mismatches for switching variants in cart

### DIFF
--- a/core/model/Cart.php
+++ b/core/model/Cart.php
@@ -495,12 +495,15 @@ class ShoppCart extends ListFramework {
 			return true;
 
 		// Maintain item state, change variant
-		$Item = $this->get($item);
-		$category = $Item->category;
-		$data = $Item->data;
+		$Item 		= $this->get($item);
+		$quantity 	= $Item->quantity;
+		$category 	= $Item->category;
+		$data 		= $Item->data;
 
-		$Item->load(new ShoppProduct($product), $pricing, $category, $data, $addons);
-		ShoppOrder()->Shiprates->item( new ShoppShippableItem($Item) );
+		// remove original product/variant
+		$this->rmvitem($item);
+		// add new product/variant
+		$this->additem($quantity, new ShoppProduct($product), $pricing, $category, $data, $addons);
 
 		return true;
 	}

--- a/core/model/Totals.php
+++ b/core/model/Totals.php
@@ -71,7 +71,7 @@ class OrderTotals extends ListFramework {
 		// If id is not provided, return the entire register
 		if ( ! isset($id) ) return $Register;
 
-		if ( ! isset($Register[$id]) ) return false;
+		if ( ! isset($Register[$id]) ) return $false;
 		return $Register[$id];
 	}
 


### PR DESCRIPTION
Only changing the variation and adding the product to Shiprates leads to problems with shipping costs calculations, discounts and taxes. For example, shipping fees set per product will be added but not removed when changing one variant into another in cart. The same goes for changing a shipped variant to a downloadable variant in cart.

This can be prevented by removing the original product/variant combination from cart and adding the new one.