### PR TITLE
The logic for displaying add-on prices seems backwards.

### DIFF
--- a/api/theme/purchase.php
+++ b/api/theme/purchase.php
@@ -777,7 +777,7 @@ class ShoppPurchaseThemeAPI implements ShoppAPI {
 
 		foreach ( $item->addons->meta as $id => $addon ) {
 			if ( in_array($addon->name, (array)$excludes) ) continue;
-			if ( 'inclusive' == $O->taxing )
+			if ( 'inclusive' != $O->taxing )
 				$price = $addon->value->unitprice + ( $addon->value->unitprice * $taxrate );
 			else $price = $addon->value->unitprice;
 


### PR DESCRIPTION
Taxes should only be added for non-inclusive (add-on) prices