### PR TITLE
Fixing cart.referrer issue

### DIFF
--- a/core/flow/Storefront.php
+++ b/core/flow/Storefront.php
@@ -343,7 +343,7 @@ class ShoppStorefront extends ShoppFlowController {
 		if ( ! is_shopp_catalog_page() || is_shopp_cart_page() ) return;
 
 		 // Track referrer for the cart referrer URL
-		$referrer = get_bloginfo('url') . '/' . trim($_SERVER['REQUEST_URI'], '/');
+		$referrer = get_bloginfo('url') . '/' . $wp->request;
 
 		$this->referrer = user_trailingslashit($referrer);
 


### PR DESCRIPTION
Using `get_bloginfo('url') . '/' . trim($_SERVER['REQUEST_URI']` results in double appearance of subfolder in case WP is installed in a subfolder. Both, `get_bloginfo('url')` and `$_SERVER['REQUEST_URI']` include the subfolder.

Switching back to `$wp->request` solves the issue.