### PR TITLE
Fix #3583

### DIFF
--- a/api/theme/storefront.php
+++ b/api/theme/storefront.php
@@ -1743,7 +1743,7 @@ class ShoppCategoryWalker extends Walker {
 		$smartcollection = $category->taxonomy == get_class_property( 'SmartCollection', 'taxon');
 		$categoryname = $category->name;
 
-        $href = shopp($category, 'get-url');
+        $href = get_term_link($category);
 
 		$classes = '';
 		if ( 'list' == $args['style'] ) {


### PR DESCRIPTION
$category is a WP_Term Object, not a ShoppCollection Object.