### PR TITLE
Fix price metadata on product collections

### DIFF
--- a/core/model/Product.php
+++ b/core/model/Product.php
@@ -576,6 +576,8 @@ class ShoppProduct extends WPShoppObject {
 
 		// Build secondary lookup table using the price id as the key
 		$target->priceid[$price->id] = $price;
+		if( isset($this->products) && !empty($this->products) )
+			$this->priceid[$price->id] = $price;
 
 		// Set promoprice before data aggregation
 		if (Shopp::str_true($price->sale)) $price->promoprice = $price->saleprice;


### PR DESCRIPTION
Fixes a logic error that prevented price metadata from loading in collections that was introduced in Shopp 1.2.