### PR TITLE
Fix bug with quantity dropdown size default.

### DIFF
--- a/api/theme/product.php
+++ b/api/theme/product.php
@@ -1498,7 +1498,7 @@ class ShoppProductThemeAPI implements ShoppAPI {
 			'labelpos' => 'before',
 			'label' => '',
 			'options' => '1-15,20,25,30,40,50,75,100',
-			'size' => false
+			'size' => '1'
 		);
 		$options = array_merge($defaults, $options);
 		$attributes = $options;


### PR DESCRIPTION
Setting size to false results in an empty size attribute. In Safari and Firefox, this causes the element to be rendered without a dropdown arrow.