### PR TITLE
Fixed address and purchase record saving for USAF and USAT

### DIFF
--- a/core/model/Address.php
+++ b/core/model/Address.php
@@ -113,6 +113,19 @@ class ShoppAddress extends ShoppDatabaseObject {
 
 	}
 
+	/**
+	 * Overloads the default save to truncate the country code
+	 *
+	 * @author Matthew Sigley
+	 * @since 1.4
+	 *
+	 * @return void
+	 **/
+	public function save () {
+		$this->country = substr( $this->country, 0, 2 );
+		parent::save();
+	}
+
 } // END class Address
 
 

--- a/core/model/Purchase.php
+++ b/core/model/Purchase.php
@@ -740,6 +740,9 @@ class ShoppPurchase extends ShoppDatabaseObject {
 		if ( ! empty($this->card) )
 			$this->card = PayCard::truncate($this->card);
 
+		$this->country = substr( $this->country, 0, 2 );
+		$this->shipcountry = substr( $this->shipcountry, 0, 2 );
+
 		parent::save();
 	}
 


### PR DESCRIPTION
Truncates country codes in address and purchase records to two characters. The out of range INSERT call was causing issues under Maria DB. I imagine it would cause similar issues if your MySQL server was set to "strict mode".