### PR TITLE
Fix #3628 weak typing evaluation in copydata()

### DIFF
--- a/core/library/DB.php
+++ b/core/library/DB.php
@@ -1322,7 +1322,7 @@ abstract class ShoppDatabaseObject implements Iterator {
 	 * @return void
 	 **/
 	public function copydata ( $data, $prefix = '', $ignores = false ) {
-		if ( ! is_array($ignores) || ! $ignores ) $ignores = array('_datatypes', '_table', '_key', '_lists', '_map', 'id', 'created', 'modified');
+		if ( ! is_array($ignores) || $ignores === false ) $ignores = array('_datatypes', '_table', '_key', '_lists', '_map', 'id', 'created', 'modified');
 
 		$properties = is_object($data) ? get_object_vars($data) : $data;
 		foreach ( (array)$properties as $property => $value ) {


### PR DESCRIPTION
This is a pretty major bug as any copydata() use that passes in an empty array ends up with all of the default ignore properties.

This particuarly caused a bug with the Login controller wherein the loaded ShoppCustomer object did not have the customer’s ID set, causing the My Account screens to malfuction.