### PR TITLE
Fix report table view.

### DIFF
--- a/core/flow/Admin.php
+++ b/core/flow/Admin.php
@@ -1103,7 +1103,7 @@ class ShoppAdminListTable extends WP_List_Table {
 
 		if ( !empty( $columns ) ) {
 			$this->_columns = $columns;
-			add_filter( 'manage_' . $screen->id . '_columns', array( &$this, 'get_columns' ), 0 );
+			add_filter( 'manage_' . $screen->id . '_columns', array( &$this, 'get_columns' ), 1 );
 		}
 
 	}

--- a/core/flow/Report.php
+++ b/core/flow/Report.php
@@ -284,7 +284,7 @@ abstract class ShoppReportFramework {
 		$this->totals  = new StdClass();
 
 		add_action('shopp_report_filter_controls', array($this, 'filters'));
-		add_action("manage_{$this->screen}_columns", array($this, 'screencolumns'));
+		add_action("manage_{$this->screen}_columns", array($this, 'screencolumns'), 0);
 		add_action("manage_{$this->screen}_sortable_columns", array($this, 'sortcolumns'));
 	}
 


### PR DESCRIPTION
Using manage_{$this->screen}_columns as an action causes it send back a NULL result to the filter, blowing away the data that is registered further down the pipe.