### PR TITLE
Add a consistent API for extending admin table data.

### DIFF
--- a/core/library/AdminTable.php
+++ b/core/library/AdminTable.php
@@ -1043,7 +1043,11 @@ abstract class ShoppAdminTable extends ShoppRequestFramework {
 		$row_class = ( $row_class == '' ? ' class="alternate"' : '' );
 
 		echo '<tr ' . $row_class .  ( empty($item->id) ? '' : ' id="list-item-' . $item->id . '"' ) . '>';
+
+		do_action('shopp_{$this->screen->id}_column_before');
 		$this->single_row_columns( $item );
+		do_action('shopp_{$this->screen->id}_column_after');
+
 		echo '</tr>';
 	}
 
@@ -1096,22 +1100,27 @@ abstract class ShoppAdminTable extends ShoppRequestFramework {
 				$style = ' style="display:none;"';
 
 			$attributes = "$class$style";
+			$attributes = apply_filters('shopp_{$this->screen->id}_column_{$column_name}_wrap_attributes', $attributes);
+
+			$content = '';
+			$wrap_open = "<td $attributes>";
+			$wrap_close = "</td>";
 
 			if ( 'cb' == $column_name ) {
-				echo '<th scope="row" class="check-column">';
-				echo $this->column_cb( $item );
-				echo '</th>';
+				$wrap_open = '<th scope="row" class="check-column">';
+				$content = $this->column_cb( $item );
+				$wrap_close = "</th>";
+			} elseif ( method_exists( $this, 'column_' . $column_name ) ) {
+				$content = call_user_func( array( $this, 'column_' . $column_name ), $item );
+			} else {
+				$content = $this->column_default( $item, $column_name );
 			}
-			elseif ( method_exists( $this, 'column_' . $column_name ) ) {
-				echo "<td $attributes>";
-				echo call_user_func( array( $this, 'column_' . $column_name ), $item );
-				echo "</td>";
-			}
-			else {
-				echo "<td $attributes>";
-				echo $this->column_default( $item, $column_name );
-				echo "</td>";
-			}
+
+			$content = apply_filters('shopp_{$this->screen->id}_column_{$column_name}_content', $content);
+
+			echo $wrap_open;
+			echo $content;
+			echo $wrap_close;
 		}
 	}
 

--- a/core/library/AdminTable.php
+++ b/core/library/AdminTable.php
@@ -1100,7 +1100,7 @@ abstract class ShoppAdminTable extends ShoppRequestFramework {
 				$style = ' style="display:none;"';
 
 			$attributes = "$class$style";
-			$attributes = apply_filters('shopp_{$this->screen->id}_column_{$column_name}_wrap_attributes', $attributes);
+			$attributes = apply_filters('shopp_{$this->screen->id}_column_{$column_name}_attributes', $attributes);
 
 			$content = '';
 			$wrap_open = "<td $attributes>";

--- a/core/screens/Orders.php
+++ b/core/screens/Orders.php
@@ -557,16 +557,16 @@ class ShoppOrdersTable extends ShoppAdminTable {
 	}
 
 	public function column_default( $Item ) {
-		echo '.';
+		return '.';
 	}
 
 	public function column_cb( $Item ) {
-		echo '<input type="checkbox" name="selected[]" value="' . $Item->id . '" />';
+		return '<input type="checkbox" name="selected[]" value="' . $Item->id . '" />';
 	}
 
 	public function column_order( $Item ) {
 		$url = add_query_arg('id', $Item->id);
-		echo '<a class="row-title" href="' . esc_url($url) . '" title="' . Shopp::__('View Order #%d', $Item->id) . '">' . Shopp::__('Order #%d', $Item->id) . '</a>';
+		return '<a class="row-title" href="' . esc_url($url) . '" title="' . Shopp::__('View Order #%d', $Item->id) . '">' . Shopp::__('Order #%d', $Item->id) . '</a>';
 	}
 
 	public function column_name( $Item ) {
@@ -576,9 +576,9 @@ class ShoppOrdersTable extends ShoppAdminTable {
 
 		$url = add_query_arg( array( 'page' => 'shopp-customers', 'id' => $Item->customer ) );
 
-		echo '<a href="' . esc_url($url) . '">' . esc_html($customer) . '</a>';
+		return '<a href="' . esc_url($url) . '">' . esc_html($customer) . '</a>';
 		if ( '' != trim($Item->company) )
-			echo "<br />" . esc_html($Item->company);
+			return "<br />" . esc_html($Item->company);
 	}
 
 	public function column_destination( $Item ) {
@@ -594,31 +594,31 @@ class ShoppOrdersTable extends ShoppAdminTable {
 			$location = str_replace('&mdash; ', '', $location);
 		$location = str_replace(',   &mdash;', ' &mdash;', $location);
 
-		echo esc_html($location);
+		return esc_html($location);
 	}
 
 	public function column_txn( $Item ) {
-		echo $Item->txnid;
+		return $Item->txnid;
 
 		if ( isset($this->gateways[ $Item->gateway ]) )
 			echo '<br />' . esc_html($this->gateways[ $Item->gateway ]->name);
 	}
 
 	public function column_date( $Item ) {
-		echo date($this->dates, mktimestamp($Item->created));
+		return date($this->dates, mktimestamp($Item->created));
 
 		if ( isset($this->statuses[ $Item->status ]) )
-			echo '<br /><strong>' . esc_html($this->statuses[ $Item->status ]) . '</strong>';
+			return '<br /><strong>' . esc_html($this->statuses[ $Item->status ]) . '</strong>';
 	}
 
 	public function column_total( $Item ) {
-		echo money($Item->total);
+		return money($Item->total);
 
 		$status = $Item->txnstatus;
 		if ( isset($this->txnstatuses[ $Item->txnstatus ]) )
 			$status = $this->txnstatuses[ $Item->txnstatus ];
 
-		echo '<br /><span class="status">' . esc_html($status) . '</span>';
+		return '<br /><span class="status">' . esc_html($status) . '</span>';
 	}
 
 } // class ShoppOrdersTable

--- a/core/screens/Orders.php
+++ b/core/screens/Orders.php
@@ -481,7 +481,7 @@ class ShoppOrdersTable extends ShoppAdminTable {
 
 		$exports = array(
 			'tab' => Shopp::__('Tab-separated.txt'),
-			'csv' => Shopp::__('Comma-separated.csv'),			
+			'csv' => Shopp::__('Comma-separated.csv'),
 			'iif' => Shopp::__('Intuit&reg; QuickBooks.iif')
 		);
 
@@ -557,7 +557,7 @@ class ShoppOrdersTable extends ShoppAdminTable {
 	}
 
 	public function column_default( $Item ) {
-		return '.';
+		return '';
 	}
 
 	public function column_cb( $Item ) {

--- a/core/screens/Pages.php
+++ b/core/screens/Pages.php
@@ -129,7 +129,7 @@ class ShoppPagesSettingsTable extends ShoppAdminTable {
 	}
 
 	public function column_default( $Item ) {
-		echo '.';
+		return '.';
 	}
 
 	public function column_title( $Item ) {
@@ -137,20 +137,20 @@ class ShoppPagesSettingsTable extends ShoppAdminTable {
 
 		$edit_link = wp_nonce_url(add_query_arg('edit', $Item->id), 'shopp-settings-pages');
 
-		echo '<a class="row-title edit" href="' . $edit_link . '" title="' . Shopp::__('Edit') . ' &quot;' . esc_attr($title) . '&quot;">' . esc_html($title) . '</a>';
+		return '<a class="row-title edit" href="' . $edit_link . '" title="' . Shopp::__('Edit') . ' &quot;' . esc_attr($title) . '&quot;">' . esc_html($title) . '</a>';
 
-		echo $this->row_actions( array(
+		return $this->row_actions( array(
 			'edit' => '<a class="edit" href="' . $edit_link . '">' . __( 'Edit' ) . '</a>'
 		) );
 
 	}
 
 	public function column_slug( $Item ) {
-		echo esc_html($Item->slug);
+		return esc_html($Item->slug);
 	}
 
 	public function column_description( $Item ) {
-		echo esc_html($Item->description);
+		return esc_html($Item->description);
 	}
 
 } // class ShoppPagesSettingsTable

--- a/core/screens/Pages.php
+++ b/core/screens/Pages.php
@@ -53,12 +53,12 @@ class ShoppScreenPages extends ShoppSettingsScreenController {
 		include $this->ui('pages.php');
 
 	}
-	
+
 	public function url ( $params = array() ) {
 		$url = parent::url($params);
 		return remove_query_arg('edit', $url);
 	}
-	
+
 
 } // class ShoppScreenPages
 
@@ -87,7 +87,7 @@ class ShoppPagesSettingsTable extends ShoppAdminTable {
 			$page['id'] = $name;
 			$this->items[ $name ] = (object) array_merge($template, $page);
 		}
-		
+
 		$per_page = 25;
 		$total = count($this->items);
 		$this->set_pagination_args( array(
@@ -124,12 +124,12 @@ class ShoppPagesSettingsTable extends ShoppAdminTable {
 			'${slug}' => $Item->slug,
 			'${description}' => $Item->description
 		);
-		
+
 		echo ShoppUI::template($this->editor, $data);
 	}
 
 	public function column_default( $Item ) {
-		return '.';
+		return '';
 	}
 
 	public function column_title( $Item ) {


### PR DESCRIPTION
Add hooks to admin table generator.

shopp_{$this->screen->id}_column_before
shopp_{$this->screen->id}_column_after
shopp_{$this->screen->id}_column_{$column_name}_wrap_attributes
shopp_{$this->screen->id}_column_{$column_name}_content