### PR TITLE
Adjust orderby evalutation

### DIFF
--- a/core/model/Collection.php
+++ b/core/model/Collection.php
@@ -114,48 +114,46 @@ class ProductCollection implements Iterator {
 		}
 
 		// Sort Order
-		if ( ! $orderby ) {
+		$titlesort = "p.post_title ASC";
+		$defaultsort = empty($order) ? $titlesort : $order;
 
-			$titlesort = "p.post_title ASC";
-			$defaultsort = empty($order) ? $titlesort : $order;
+		// Define filterable built-in sort methods (you're welcome)
+		$sortmethods = apply_filters('shopp_collection_sort_methods', array(
+			'bestselling' => "s.sold DESC,$titlesort",
+			'highprice'   => "maxprice DESC,$titlesort",
+			'lowprice'    => "minprice ASC,$titlesort",
+			'newest'      => "p.post_date DESC,$titlesort",
+			'oldest'      => "p.post_date ASC,$titlesort",
+			'random'      => "RAND(".crc32($Shopping->session).")",
+			'chaos'       => "RAND(".time().")",
+			'reverse'     => "p.post_title DESC",
+			'title'       => $titlesort,
+			'custom'      => is_subclass_of($this,'ProductTaxonomy') ? "tr.term_order ASC,$titlesort" : $defaultsort,
+			'recommended' => is_subclass_of($this,'ProductTaxonomy') ? "tr.term_order ASC,$titlesort" : $defaultsort,
+			'default'     => $defaultsort
+		));
 
-			// Define filterable built-in sort methods (you're welcome)
-			$sortmethods = apply_filters('shopp_collection_sort_methods', array(
-				'bestselling' => "s.sold DESC,$titlesort",
-				'highprice'   => "maxprice DESC,$titlesort",
-				'lowprice'    => "minprice ASC,$titlesort",
-				'newest'      => "p.post_date DESC,$titlesort",
-				'oldest'      => "p.post_date ASC,$titlesort",
-				'random'      => "RAND(".crc32($Shopping->session).")",
-				'chaos'       => "RAND(".time().")",
-				'reverse'     => "p.post_title DESC",
-				'title'       => $titlesort,
-				'custom'      => is_subclass_of($this,'ProductTaxonomy') ? "tr.term_order ASC,$titlesort" : $defaultsort,
-				'recommended' => is_subclass_of($this,'ProductTaxonomy') ? "tr.term_order ASC,$titlesort" : $defaultsort,
-				'default'     => $defaultsort
-			));
+		// Handle valid user browsing sort change requests
+		if ( isset($_REQUEST['sort']) && !empty($_REQUEST['sort']) && array_key_exists(strtolower($_REQUEST['sort']), $sortmethods) )
+			$Storefront->browsing['sortorder'] = strtolower($_REQUEST['sort']);
 
-			// Handle valid user browsing sort change requests
-			if ( isset($_REQUEST['sort']) && !empty($_REQUEST['sort']) && array_key_exists(strtolower($_REQUEST['sort']), $sortmethods) )
-				$Storefront->browsing['sortorder'] = strtolower($_REQUEST['sort']);
+		// Collect sort setting sources (Shopp admin setting, User browsing setting, programmer specified setting)
+		$sortsettings = array(
+			shopp_setting('default_product_order'),
+			isset($Storefront->browsing['sortorder']) ? $Storefront->browsing['sortorder'] : false,
+			!empty($order) ? $order : false
+		);
 
-			// Collect sort setting sources (Shopp admin setting, User browsing setting, programmer specified setting)
-			$sortsettings = array(
-				shopp_setting('default_product_order'),
-				isset($Storefront->browsing['sortorder']) ? $Storefront->browsing['sortorder'] : false,
-				!empty($order) ? $order : false
-			);
+		// Go through setting sources to determine most applicable setting
+		$sorting = 'title';
+		foreach ($sortsettings as $setting)
+			if ( ! empty($setting) && isset($sortmethods[ strtolower($setting) ]) )
+				$sorting = strtolower($setting);
 
-			// Go through setting sources to determine most applicable setting
-			$sorting = 'title';
-			foreach ($sortsettings as $setting)
-				if ( ! empty($setting) && isset($sortmethods[ strtolower($setting) ]) )
-					$sorting = strtolower($setting);
-
+		if ( ! $orderby )
 			$orderby = $sortmethods[ $sorting ];
-		}
-
-		if ( empty($orderby) ) $orderby = 'p.post_title ASC';
+		else
+			$orderby = $orderby . ',' . $sortmethods[ $sorting ];
 
 		// Pagination
 		if ( empty($limit) ) {


### PR DESCRIPTION
When `$orderby` is set in one of the smartcategory Classes, the evaluation of the `order` that might be set in the shopp() command is skipped due to the 'if ( ! $orderby)` condition.

Moving that check a little further down the code makes it work for all categories, with and without additional order settings.