### PR TITLE
Add htmlspecialchars_decode()

### DIFF
--- a/core/model/Discounts.php
+++ b/core/model/Discounts.php
@@ -736,6 +736,11 @@ class ShoppDiscountRule {
 		$op       = strtolower($this->logic);
 		$value    = $this->value;
 
+		// To make evaluate work correctly when
+		// $subject includes htmlencoded characters like &amp;
+        foreach ( $subject as $key => $sub )
+        	$subject[ $key ] = htmlspecialchars_decode($sub);
+
 		switch( $op ) {
 			// String or Numeric operations
 			case 'is equal to':

--- a/core/model/Discounts.php
+++ b/core/model/Discounts.php
@@ -738,8 +738,12 @@ class ShoppDiscountRule {
 
 		// To make evaluate work correctly when
 		// $subject includes htmlencoded characters like &amp;
-        foreach ( $subject as $key => $sub )
-        	$subject[ $key ] = htmlspecialchars_decode($sub);
+		if ( is_array($subject) ) {
+        	foreach ( $subject as $key => $sub )
+        		$subject[ $key ] = htmlspecialchars_decode($sub);
+        } elseif ( is_string($subject) ) {
+			$subject = htmlspecialchars_decode($subject);
+		}
 
 		switch( $op ) {
 			// String or Numeric operations


### PR DESCRIPTION
Use htmlspecialchars_decode() to make discounts work for categories with & in name.