### PR TITLE
Fix #3496 Adding flag for unescape action

### DIFF
--- a/core/library/DB.php
+++ b/core/library/DB.php
@@ -246,9 +246,10 @@ class sDB extends SingletonFramework {
 	 * @since 1.0
 	 *
 	 * @param string|array|object $data Data to be escaped
+	 * @param boolean $unescape Whether or not to unescape() before escape()
 	 * @return string Database-safe data
 	 **/
-	public static function escape ( $data ) {
+	public static function escape ( $data, $unescape = true ) {
 		// Prevent double escaping by stripping any existing escapes out
 		if ( is_array($data) ) array_map(array(__CLASS__, 'escape'), $data);
 		elseif ( is_object($data) ) {
@@ -256,7 +257,9 @@ class sDB extends SingletonFramework {
 				$data->$p = self::escape($v);
 		} else {
 			$db = sDB::get();
-			$data = self::unescape($data); // Prevent double-escapes
+			if ( $unescape === true )
+				$data = self::unescape($data); // Prevent double-escapes
+
 			$data = $db->api->escape($data);
 		}
 		return $data;

--- a/storage/core/DBStorage.php
+++ b/storage/core/DBStorage.php
@@ -54,7 +54,7 @@ class DBStorage extends StorageModule implements StorageEngine {
 			$data = file_get_contents($data);
 		}
 
-		$data = sDB::escape($data);
+		$data = sDB::escape($data, false); //Prevent unescape() before escape()
 
 		if ( ! $asset->id ) $uri = sDB::query("INSERT $this->_table SET data='$data'");
 		else sDB::query("UPDATE $this->_table SET data='$data' WHERE $this->_key='$asset->uri'");


### PR DESCRIPTION
It seems only the `save()` action in `Class DBStorage` suffers from the automatically performed `unescape()` before `escape()`.