### PR TITLE
1.3.x Taxcalculation adjustment mostly inclusivetaxes

### DIFF
--- a/api/theme/product.php
+++ b/api/theme/product.php
@@ -2426,6 +2426,10 @@ new ProductOptionsMenus(<?php printf("'select%s.product%d.options'", $select_col
 
 		if ( $baserate == $appliedrate && 0 == $baserate ) return $amount;
 
+		// Handle inclusive/exclusive tax presentation options (product editor setting or api option)
+		// If the 'taxes' option is specified and the item either has inclusive taxes that apply,
+		// or the 'taxes' option is forced on (but not both) then handle taxes by either adding or excluding taxes
+		// This is an exclusive or known as XOR, the lesser known brother of Thor that gets left out of the family get togethers
 		if ( $inclusivetax ) {
 			if ( $taxoption ) {
 				if ( $baserate == $appliedrate ) return $amount;

--- a/api/theme/product.php
+++ b/api/theme/product.php
@@ -2414,32 +2414,31 @@ new ProductOptionsMenus(<?php printf("'select%s.product%d.options'", $select_col
 
 		if ( empty($taxrates) ) $taxrates = Shopp::taxrates($O);
 
+		$inclusivetax = self::_inclusive_taxes($O);
+
 		if ( isset($taxoption) )
 			$taxoption = Shopp::str_true( $taxoption );
+		else
+			$taxoption = $inclusivetax;
 
-		$inclusivetax = self::_inclusive_taxes($O);
+		$adjustment = ShoppTax::adjustment($taxrates, $O);
+		extract($adjustment);
+
+		if ( $baserate == $appliedrate && 0 == $baserate ) return $amount;
+
 		if ( $inclusivetax ) {
-			$adjustment = ShoppTax::adjustment($taxrates, $O);
-			if ( 1 != $adjustment && false !== $taxoption ) // Only adjust when taxes are not excluded @see #3041
-				return (float) ($amount / $adjustment);
-		}
-
-		// Handle inclusive/exclusive tax presentation options (product editor setting or api option)
-		// If the 'taxes' option is specified and the item either has inclusive taxes that apply,
-		// or the 'taxes' option is forced on (but not both) then handle taxes by either adding or excluding taxes
-		// This is an exclusive or known as XOR, the lesser known brother of Thor that gets left out of the family get togethers
-		if ( isset($taxoption) && ( $inclusivetax ^ $taxoption ) ) {
-
+			if ( $taxoption ) {
+				if ( $baserate == $appliedrate ) return $amount;
+				//return (float)($amount * ( 1 / ( 1 + $baserate ) ) ) * ( 1 + $appliedrate );
+				return (float)($amount / ( 1 + $baserate ) ) * ( 1 + $appliedrate );
+			} else {
+				//return (float)$amount * ( 1 / ( 1 + $baserate ) );
+				return (float)$amount / ( 1 + $baserate );
+			}
+		} else {
 			if ( $taxoption )
-				// runs when 'taxes=on' and tax-inclusive prices disabled
-				return $amount + ShoppTax::calculate($taxrates, (float)$amount);
-			elseif ( empty($taxrates) )
-				// runs when 'taxes=off' and tax-inclusive prices enabled and product not taxable
-				return $amount / $adjustment;
-			else
-				// runs when 'taxes=off' and tax-inclusive prices enabled and product is taxable
-				return ShoppTax::exclusive($taxrates, (float)$amount);
-		}
+				return (float)$amount * ( 1 + $appliedrate );
+		}		
 
 		return $amount;
 	}

--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -392,7 +392,7 @@ class ShoppCartItem {
 	 * @param float $taxrate (optional) The tax rate to apply to pricing information
 	 * @return string
 	 **/
-	public function options ($selection = '') {
+	public function options ( $selection = '' ) {
 		if ( empty($this->variants) ) return '';
 
 		$string = '';
@@ -406,7 +406,7 @@ class ShoppCartItem {
 			if ( $option->type == 'N/A' ) continue;
 
 			if ( $priceline != $option->id ) {
-				$currently = ( Shopp::str_true($option->sale) ) ? $option->promoprice : $option->price;
+				$currently = ( ( Shopp::str_true($option->sale) ) ? $option->promoprice : $option->price ) + $this->addonsum;
 				if ( $adjustment < 0 )
 					$adjustment = 1 + $adjustment;
 
@@ -414,6 +414,9 @@ class ShoppCartItem {
 					$difference = (float)($currently-$this->unitprice);
 				else
 					$difference = (float)(($currently / $adjustment) - $this->unitprice);
+
+				if ( isset($taxoption) && ( $inclusivetax ^ $taxoption ) )
+					$difference = $difference + ( $difference * $this->taxrate );
 			} else {
 				$difference = 0;
 			}
@@ -428,7 +431,7 @@ class ShoppCartItem {
 			if ( Shopp::str_true($option->inventory) && $option->stock < $this->quantity && ! shopp_setting_enabled('backorders') )
 				$disabled = ' disabled="disabled"';
 
-			$string .= '<option value="' . $option->id . '"' . $selected.$disabled . '>' . $option->label . $price . '</option>';
+			$string .= '<option value="' . $option->id . '"' . $selected . $disabled . '>' . $option->label . $price . '</option>';
 		}
 		return $string;
 
@@ -951,21 +954,23 @@ class ShoppCartItem {
 		$taxableqty = ( $this->bogof && $this->bogof != $this->quantity ) ? $this->quantity - $this->bogof : $this->quantity;
 
 		$Tax->rates($this->taxes, $Tax->item($this));
-
-		$this->unittax = ShoppTax::calculate($this->taxes, $taxable);
+		$this->unittax = ShoppTax::calculate($this->taxes, $taxable, $this);
 		$this->tax = $Tax->total($this->taxes, (int) $taxableqty);
 
 		// Handle inclusive tax price adjustments for non-EU markets or alternate tax rate markets
+		$inclusivetax = Shopp::str_true(shopp_setting_enabled('tax_inclusive'));
 		$adjustment = ShoppTax::adjustment($this->taxes, $this);
-		if ( 1 != $adjustment ) {
+		extract($adjustment);
 
+		if ( $baserate != $appliedrate ) {
 			if ( ! isset($this->taxprice) )
 				$this->taxprice = $this->unitprice;
-
-			// Modify the unitprice from the original tax inclusive price and update the discounted price
-			$this->unitprice = ( $this->taxprice / $adjustment );
-			$this->priced = ( $this->unitprice - $this->discount );
-
+			
+			if ( $inclusivetax ) { 
+				// Modify the unitprice from the original tax inclusive price and update the discounted price
+				$this->unitprice = ( $this->taxprice / ( 1 + $baserate ) ) * ( 1 + $appliedrate );
+				$this->priced = ( $this->unitprice - $this->discount );
+			}
 		} elseif ( isset($this->taxprice) ) { // Undo tax price adjustments
 			$this->unitprice = $this->taxprice;
 			unset($this->taxprice);


### PR DESCRIPTION
Changed output of `adjustment()` function to return an array with baserate and appliedrate instead of a calculated fraction. This makes it easier to deduct baserate portion of productprice when prices include VAT.

Check for more specific taxes when EU-union tax is set. This makes it possible to set a different VAT percentage for an EU country (see #3426).

Reflect price/tax/country changes for variations and addons in cart.

Correct calculations when using taxrules in combination with inclusive prices.