### PR TITLE
Preventing Fatal error on activation (PHP7.1)

### DIFF
--- a/core/library/DB.php
+++ b/core/library/DB.php
@@ -980,7 +980,7 @@ abstract class ShoppDatabaseObject implements Iterator {
 		}
 
 		if ( $Settings->available() ) {
-
+			if ( empty($Tables) ) $Tables = array();
 			$Tables[ $this->_table ] = new StdClass();
 			$Tables[ $this->_table ]->_datatypes =& $this->_datatypes;
 			$Tables[ $this->_table ]->_lists =& $this->_lists;


### PR DESCRIPTION
Activating Shopp 1.3.12+ with PHP 7.1 results in
Fatal error: Uncaught Error: Cannot use string offset as an object in /wp-content/plugins/shopp/core/library/DB.php:985 

Stack trace:
#0 /wp-content/plugins/shopp/core/model/Asset.php(665): ShoppDatabaseObject->init('meta')
#1 /wp-content/plugins/shopp/core/flow/Install.php(343): ImageSetting->__construct()
#2 /wp-content/plugins/shopp/core/flow/Install.php(436): ShoppInstallation->images()
#3 /wp-includes/class-wp-hook.php(298): ShoppInstallation->setup('')
#4 /wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters('', Array)
#5 /wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#6 /wp-content/plugins/shopp/core/library/DB.php on line 985

When $Settings->available() returns true, and $Settings->get('data_model') returns empty/null $Tables is a string, not an array.