### PR TITLE
Update CI test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 # Travis CI Configuration File
 
-# Use container infrastructure
-sudo: false
-
 # Tell Travis CI we're using PHP
 language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6"
+    - "7.1.4"
 
 # WordPress version used in first build configuration.
 env:
-    - WP_VERSION=4.4.2
+    - WP_VERSION=master
 
 # Next we define our matrix of additional build configurations to test against.
 # The versions listed above will automatically create our first configuration,
@@ -29,10 +26,10 @@ env:
 
 matrix:
   include:
-     - php: "7.0"
-       env: WP_VERSION=master
-     - php: "5.3"
-       env: WP_VERSION=4.0
+     - php: "7.0.18"
+       env: WP_VERSION=4.7.4
+     - php: "5.6.30"
+       env: WP_VERSION=4.6.5
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
Bleeding edge: PHP 7.1.4 vs WP dev
Current releases: PHP 7.0.18 vs WP 4.7.4
Legacy releases: PHP 5.6.30 vs WP 4.6.5