### PR TITLE
Update test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.1"
+    - "7.1.4"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,9 +26,9 @@ env:
 
 matrix:
   include:
-     - php: "7.0"
+     - php: "7.0.17"
        env: WP_VERSION=4.7.4
-     - php: "5.6"
+     - php: "5.6.30"
        env: WP_VERSION=4.6.5
 
 # Clones WordPress and configures our testing environment.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.5"
+    - "7.1.4"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,14 +26,10 @@ env:
 
 matrix:
   include:
-     - php: "5.3"
-       env: WP_VERSION=4.4
-    # - php: "5.4"
-    #   env: WP_VERSION=4.4
-    # - php: "5.3"
-    #   env: WP_VERSION=4.2
-    # - php: "5.2"
-    #   env: WP_VERSION=4.0
+     - php: "7.0.18"
+       env: WP_VERSION=4.7.4
+     - php: "5.6.30"
+       env: WP_VERSION=4.6.5
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.1.4"
+    - "7.1"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,9 +26,9 @@ env:
 
 matrix:
   include:
-     - php: "7.0.18"
+     - php: "7.0"
        env: WP_VERSION=4.7.4
-     - php: "5.6.30"
+     - php: "5.6"
        env: WP_VERSION=4.6.5
 
 # Clones WordPress and configures our testing environment.


### PR DESCRIPTION
Bleeding edge: PHP 7.1.4 vs WP dev
Current releases: PHP 7.0.18 vs WP 4.7.4
Legacy releases: PHP 5.6.30 vs WP 4.6.5