### PR TITLE
Update CI for temporary test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.5"
-
+    - "5.6.30"
 # WordPress version used in first build configuration.
 env:
     - WP_VERSION=master
@@ -26,14 +25,10 @@ env:
 
 matrix:
   include:
-     - php: "5.3"
-       env: WP_VERSION=4.4
-    # - php: "5.4"
-    #   env: WP_VERSION=4.4
-    # - php: "5.3"
-    #   env: WP_VERSION=4.2
-    # - php: "5.2"
-    #   env: WP_VERSION=4.0
+     - php: "5.6.30"
+       env: WP_VERSION=4.7.4
+     - php: "5.3.29"
+       env: WP_VERSION=4.6.5
 
 # Clones WordPress and configures our testing environment.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ env:
 matrix:
   include:
      - php: "5.6.30"
-       env: WP_VERSION=4.7.4
+       env: WP_VERSION=4.7
      - php: "5.3.29"
-       env: WP_VERSION=4.6.5
+       env: WP_VERSION=4.6
 
 # Clones WordPress and configures our testing environment.
 before_script:


### PR DESCRIPTION
Bleeding edge: PHP 5.6.30 vs WordPress development branch
Current: release: PHP 5.6.30 vs WordPress 4.7.4
Legacy release: PHP 5.3.29 vs WordPress 4.6.5