### PR TITLE
1.3.x Update CI for temporary test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6"
+    - "5.6.5"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,8 +26,12 @@ env:
 
 matrix:
   include:
-     - php: "5.3"
-       env: WP_VERSION=4.4
+     - php: "5.6.5"
+       env: WP_VERSION=4.7.4
+     - php: "5.3.29"
+       env: WP_VERSION=4.6.5
+    # - php: "5.3"
+    #   env: WP_VERSION=4.4
     # - php: "5.4"
     #   env: WP_VERSION=4.4
     # - php: "5.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6.30"
+    - "7.0"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.0"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.5"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6"
+    - "7.0"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6.5"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,7 +26,7 @@ env:
 
 matrix:
   include:
-     - php: "5.6.5"
+     - php: "5.6"
        env: WP_VERSION=4.7.4
      - php: "5.3.29"
        env: WP_VERSION=4.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.0"
+    - "5.6.30"
 
 # WordPress version used in first build configuration.
 env:


### PR DESCRIPTION
Bleeding edge: PHP 5.6.5 vs WordPress development branch
Current: release: PHP 5.6.5 vs WordPress 4.7.4
Legacy release: PHP 5.3.29 vs WordPress 4.6.5