### PR TITLE
Preventing too few arguments warning

### DIFF
--- a/core/library/AdminTable.php
+++ b/core/library/AdminTable.php
@@ -414,7 +414,7 @@ abstract class ShoppAdminTable extends ShoppRequestFramework {
 	 */
 	protected function bulk_actions( $which = '' ) {
 		if ( is_null( $this->_actions ) ) {
-			$no_new_actions = $this->_actions = $this->get_bulk_actions();
+			$no_new_actions = $this->_actions = $this->get_bulk_actions( $which );
 			/**
 			 * Filter the list table Bulk Actions drop-down.
 			 *


### PR DESCRIPTION
Use `$which` as an argument. 

Assuming the `get_bulk_actions` will return more than just an empty array eventually.