### PR TITLE
1.3.x Added check for multiple EUVAT rates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6"
+    - "5.6.5"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,8 +26,12 @@ env:
 
 matrix:
   include:
-     - php: "5.3"
-       env: WP_VERSION=4.4
+     - php: "5.6.5"
+       env: WP_VERSION=4.7.4
+     - php: "5.3.29"
+       env: WP_VERSION=4.6.5
+    # - php: "5.3"
+    #   env: WP_VERSION=4.4
     # - php: "5.4"
     #   env: WP_VERSION=4.4
     # - php: "5.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6.30"
+    - "7.0"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.0"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.5"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6"
+    - "7.0"
 
 # WordPress version used in first build configuration.
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "5.6.5"
+    - "5.6"
 
 # WordPress version used in first build configuration.
 env:
@@ -26,7 +26,7 @@ env:
 
 matrix:
   include:
-     - php: "5.6.5"
+     - php: "5.6"
        env: WP_VERSION=4.7.4
      - php: "5.3.29"
        env: WP_VERSION=4.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 # PHP version used in first build configuration.
 php:
-    - "7.0"
+    - "5.6.30"
 
 # WordPress version used in first build configuration.
 env:

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -114,7 +114,7 @@ class ShoppTax {
 			foreach ( $eukeys as $eukey )
 				unset($settings[ $eukey ]) ;
 
-		if ( count($eukeys) > 1 ) {
+		if ( count($eurates) > 1 ) {
 			//Multiple EUVAT detected, unset least specific ones
 			$arr = array();
 			foreach ( $eukeys as $eukey ){

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -62,8 +62,8 @@ class ShoppTax {
 	public function settings () {
 		if ( ! shopp_setting_enabled('taxes') ) return false;
 
-		$eu        = false;    // Track EU tax key
-		$override  =  array(); // Track taxrate overrides
+		$eukeys    = array();  // Track EUVAT keys
+		$override  = array();  // Track EU country VAT overrides
 		$taxrates  = shopp_setting('taxrates');
 		$fallbacks = array();
 		$settings  = array();
@@ -102,14 +102,33 @@ class ShoppTax {
 
 			$settings[ $key ] = $setting;
 
-			if ( self::EUVAT == $country ) $eu = $key;
+			if ( self::EUVAT == $country ) $eukeys[] = $key; 
 			if ( in_array($country, Lookup::country_euvat()) ) $override[ $key ] = $country;
 		}
 
 		if ( empty($settings) && ! empty($fallbacks) )
 			$settings = $fallbacks;
 
-		if ( false !== $eu && ! empty($override) ) unset($settings[ $eu ]) ;
+		if ( count($eurkeys) > 0 && count($override) > 0 )
+		    // Overall EUVAT and EUVAT for specific EU country detected, unset overall EUVAT 
+			foreach ( $eukeys as $eukey )
+				unset($settings[ $eukey ]) ;
+
+		if ( count($eurates) > 1 ) {
+			//Multiple EUVAT detected, unset least specific ones
+			$arr = array();
+			foreach ( $eukeys as $eukey ){
+				$score = 0;
+				if ( ! empty($settings[ $eukey ]['zone']) ) $score++;
+				if ( ! empty($settings[ $eukey ]['rules']) ) $score++;
+				$arr[ $score ] = $eukey;
+			}
+
+			$eurkeys = array_slice($arr, 0, count($arr)-1 );
+
+			foreach ( $eukeys as $eukey )
+				unset($settings[ $eukey ]) ;
+		}
 
 		$settings = apply_filters('shopp_cart_taxrate_settings', $settings); // @deprecated Use shopp_tax_rate_settings instead
 		return apply_filters('shopp_tax_rate_settings', $settings);

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -62,8 +62,8 @@ class ShoppTax {
 	public function settings () {
 		if ( ! shopp_setting_enabled('taxes') ) return false;
 
-		$eukeys    = array();  // Track EUVAT keys
-		$override  = array();  // Track EU country VAT overrides
+		$eu        = false;    // Track EU tax key
+		$override  =  array(); // Track taxrate overrides
 		$taxrates  = shopp_setting('taxrates');
 		$fallbacks = array();
 		$settings  = array();
@@ -102,33 +102,14 @@ class ShoppTax {
 
 			$settings[ $key ] = $setting;
 
-			if ( self::EUVAT == $country ) $eukeys[] = $key; 
+			if ( self::EUVAT == $country ) $eu = $key;
 			if ( in_array($country, Lookup::country_euvat()) ) $override[ $key ] = $country;
 		}
 
 		if ( empty($settings) && ! empty($fallbacks) )
 			$settings = $fallbacks;
 
-		if ( count($eurkeys) > 0 && count($override) > 0 )
-		    // Overall EUVAT and EUVAT for specific EU country detected, unset overall EUVAT 
-			foreach ( $eukeys as $eukey )
-				unset($settings[ $eukey ]) ;
-
-		if ( count($eurates) > 1 ) {
-			//Multiple EUVAT detected, unset least specific ones
-			$arr = array();
-			foreach ( $eukeys as $eukey ){
-				$score = 0;
-				if ( ! empty($settings[ $eukey ]['zone']) ) $score++;
-				if ( ! empty($settings[ $eukey ]['rules']) ) $score++;
-				$arr[ $score ] = $eukey;
-			}
-
-			$eurkeys = array_slice($arr, 0, count($arr)-1 );
-
-			foreach ( $eukeys as $eukey )
-				unset($settings[ $eukey ]) ;
-		}
+		if ( false !== $eu && ! empty($override) ) unset($settings[ $eu ]) ;
 
 		$settings = apply_filters('shopp_cart_taxrate_settings', $settings); // @deprecated Use shopp_tax_rate_settings instead
 		return apply_filters('shopp_tax_rate_settings', $settings);

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -114,7 +114,7 @@ class ShoppTax {
 			foreach ( $eukeys as $eukey )
 				unset($settings[ $eukey ]) ;
 
-		if ( count($eurates) > 1 ) {
+		if ( count($eukeys) > 1 ) {
 			//Multiple EUVAT detected, unset least specific ones
 			$arr = array();
 			foreach ( $eukeys as $eukey ){


### PR DESCRIPTION
Scenario:

- Base of operation : any EU country
- Prices inclusive taxes
- Taxrates: EU (in category X condition) 15%, EU general 20%, Germany 30%

The current code is not able to determine which of the 'double' EU rates is most specific. `$settings`  holds both rates and uses both rates in calculations. This results in miscalculations.

A more general approach is probably needed.


#3723