### PR TITLE
Adjust item() to prevent double typing

### DIFF
--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -47,7 +47,8 @@ class ShoppTax {
 	 * @return void
 	 **/
 	public function item ( $Item ) {
-		return new ShoppTaxableItem($Item);
+		$Item = is_a($Item, 'ShoppTaxableItem') ? $Item : new ShoppTaxableItem($Item);
+		return $Item;
 	}
 
 	/**


### PR DESCRIPTION
Without the check, this action is also performed on objects that already have the correct type. It results in errors.