### PR TITLE
Adjust taxamount calculations to differ between tax incl/excl product…

### DIFF
--- a/api/theme/product.php
+++ b/api/theme/product.php
@@ -2454,7 +2454,7 @@ new ProductOptionsMenus(<?php printf("'select%s.product%d.options'",$select_coll
 		}
         
 		if ( $inclusivetax )
-			$amount += ShoppTax::adjustment($amount, $taxrates, $O);
+			$amount = ShoppTax::adjustment($amount, $taxrates, $O);
 
 		return $amount;
 	}

--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -960,7 +960,7 @@ class ShoppCartItem {
 		$taxableqty = ( $this->bogof && $this->bogof != $this->quantity ) ? $this->quantity - $this->bogof : $this->quantity;
 
 		$Tax->rates($this->taxes, $Tax->item($this));
-		$this->unittax = ShoppTax::calculate($this->taxes, $taxable);
+		$this->unittax = ShoppTax::calculate($this->taxes, $taxable, $Tax->item($this));
 		$this->tax = $Tax->total($this->taxes, (int) $taxableqty);
 
 		// Handle inclusive tax price adjustments for non-EU markets or alternate tax rate markets

--- a/core/model/Item.php
+++ b/core/model/Item.php
@@ -960,7 +960,7 @@ class ShoppCartItem {
 		$taxableqty = ( $this->bogof && $this->bogof != $this->quantity ) ? $this->quantity - $this->bogof : $this->quantity;
 
 		$Tax->rates($this->taxes, $Tax->item($this));
-		$this->unittax = ShoppTax::calculate($this->taxes, $taxable, $Tax->item($this));
+		$this->unittax = ShoppTax::calculate($this->taxes, $taxable);
 		$this->tax = $Tax->total($this->taxes, (int) $taxableqty);
 
 		// Handle inclusive tax price adjustments for non-EU markets or alternate tax rate markets

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -378,7 +378,7 @@ class ShoppTax {
 	 * @param float $taxable The amount to calculate taxes on
 	 * @return float The total tax amount
 	 **/
-	public static function calculate ( array &$rates, $taxable ) {
+	public static function calculate ( array &$rates, $taxable, $Item = null ) {
 		$compound = $taxable;
 		$total = 0;
 		$inclusive = shopp_setting_enabled('tax_inclusive');
@@ -389,9 +389,16 @@ class ShoppTax {
 			$taxrate->amount = 0; // Reset the captured tax amount @see Issue #2430
 
 			// Calculate tax amount
-			$tax = self::tax($taxable, $taxrate->rate);
+			if ( $inclusive ) {
+				$baserates = ShoppTax::baserates($Item);
+				$baserate = reset($baserates);
+				$baserate = isset($baserate->rate) ? $baserate->rate : 0;
+				$tax = ( $taxable / (1 + $baserate) ) * $taxrate->rate;
+			} else {
+				$tax = self::tax($taxable, $taxrate->rate);
+			}
 
-			if ( $taxrate->compound ) {
+			if ( 'on' == $taxrate->compound ) {
 				$tax = self::tax($compound, $taxrate->rate);
 				$compound += $tax;						 	// Set compound taxable amount for next compound rate
 			}

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -378,7 +378,7 @@ class ShoppTax {
 	 * @param float $taxable The amount to calculate taxes on
 	 * @return float The total tax amount
 	 **/
-	public static function calculate ( array &$rates, $taxable, $Item = null ) {
+	public static function calculate ( array &$rates, $taxable ) {
 		$compound = $taxable;
 		$total = 0;
 		$inclusive = shopp_setting_enabled('tax_inclusive');
@@ -389,16 +389,9 @@ class ShoppTax {
 			$taxrate->amount = 0; // Reset the captured tax amount @see Issue #2430
 
 			// Calculate tax amount
-			if ( $inclusive ) {
-				$baserates = ShoppTax::baserates($Item);
-				$baserate = reset($baserates);
-				$baserate = isset($baserate->rate) ? $baserate->rate : 0;
-				$tax = ( $taxable / (1 + $baserate) ) * $taxrate->rate;
-			} else {
-				$tax = self::tax($taxable, $taxrate->rate);
-			}
+			$tax = self::tax($taxable, $taxrate->rate);
 
-			if ( 'on' == $taxrate->compound ) {
+			if ( Shopp::str_true($taxrate->compound) ) {
 				$tax = self::tax($compound, $taxrate->rate);
 				$compound += $tax;						 	// Set compound taxable amount for next compound rate
 			}

--- a/core/model/Tax.php
+++ b/core/model/Tax.php
@@ -303,11 +303,10 @@ class ShoppTax {
 	}
 
 	/**
-	 * Provides an adjustment amount based on EU tax zone differences
+	 * Provides an adjusted amount based on EU tax zone differences
 	 *
-	 * The adjustment amount is a +/- difference to apply to a
-	 * product or cart item price to account for the tax rate difference
-	 * between the base of operations tax rate that applies to the item
+	 * The adjusted amount is a product or cart item price based
+	 * on the base of operations tax rate that applies to the item
 	 * and the tax rate that applies to the current shipping location.
 	 *
 	 * @since 1.4
@@ -316,23 +315,19 @@ class ShoppTax {
 	 * @param object $Item A compatible taxable object
 	 * @return float The signed adjustment amount
 	 **/
-	public static function adjustment ( $amount, $rates, $Item ) {
-		if ( ! shopp_setting_enabled('tax_inclusive') ) return 0;
 
-		$baserates = ShoppTax::baserates($Item);
-		$baserate = reset($baserates);
+	public static function adjustment ( $amount, $rates, $Item ) {
+		$baserates   = ShoppTax::baserates($Item);
+		$baserate    = reset($baserates);
 		$appliedrate = self::appliedrate($rates);
 
-		$baserate = isset($baserate->rate) ? $baserate->rate : 0;
+		$baserate    = isset($baserate->rate) ? $baserate->rate : 0;
 		$appliedrate = isset($appliedrate->rate) ? $appliedrate->rate : 0;
         
-		if ( $baserate == $appliedrate )
-			return 0;
+		$netamount   = (float)$amount / (1 + $baserate);
+		$newamount   = ( $netamount * (1 + $appliedrate) );
 
-		$netamount = (float)$amount / (1 + $baserate);
-		$appliedtax = ( $netamount * $appliedrate );
-
-		return ( $netamount + $appliedtax ) - $amount;
+		return $newamount;
 	}
 
 	/**


### PR DESCRIPTION
… prices

Due to changing `$compound = 0` to `$compound = $taxable` in Class ShoppTax function calculate(), the compound check became true. Assuming it turns from default 'off' to 'on' the code in this commit checks for `if ( 'on' == $taxrate->compound )`

Like with the `adjustment()` function, the `calculate()` function needs to perform different calculations for tax inclusive/exclusive product prices, a third argument was added to `calculate()`.

The calculations performed in `calculate()` are very much like the ones in `adjustment()` so maybe this needs to be refactored. 
 